### PR TITLE
Added options to search WooCommerce log files if WC was detected

### DIFF
--- a/includes/class-directory-iterator.php
+++ b/includes/class-directory-iterator.php
@@ -135,6 +135,10 @@ class Directory_Iterator {
 				$data['path'] = WP_CONTENT_DIR;
 				$data['type'] = 'core';
 				break;
+			case ( 'wc-logs' === $option ):
+				$data['path'] = WP_CONTENT_DIR . '/uploads/wc-logs';
+				$data['type'] = 'core';
+				break;
 		}
 
 		if ( empty( $data['path'] ) ) {

--- a/includes/class-string-locator.php
+++ b/includes/class-string-locator.php
@@ -60,8 +60,13 @@ class String_Locator {
 		ob_start();
 		?>
 		<optgroup label="<?php esc_attr_e( 'Core', 'string-locator' ); ?>">
-				<option value="core"><?php esc_html_e( 'The whole WordPress directory', 'string-locator' ); ?></option>
-		<option value="wp-content"><?php esc_html_e( 'Everything under wp-content', 'string-locator' ); ?></option>
+			<option value="core"><?php esc_html_e( 'The whole WordPress directory', 'string-locator' ); ?></option>
+			<option value="wp-content"><?php esc_html_e( 'Everything under wp-content', 'string-locator' ); ?></option>
+
+		    <?php if ( function_exists( 'wc_get_logger' ) ) : ?>
+		    <option value="wc-logs"><?php esc_html_e( 'WooCommerce Log Files', 'string-locator' ); ?></option>
+		    <?php endif; ?>
+
 		</optgroup>
 		<optgroup label="<?php esc_attr_e( 'Themes', 'string-locator' ); ?>">
 			<?php echo String_Locator::get_themes_options( $search_location ); ?>


### PR DESCRIPTION
I often find myself needing to search through WC log files in order to find specific strings (order IDs, customer email addresses, etc). This PR adds an option to search through the /wp-content/uploads/wc-logs directory if the wc_get_logger() function is detected.