### PR TITLE
Fixed search results display to not assume that only one <tbody> tag would ever exist

### DIFF
--- a/includes/class-string-locator.php
+++ b/includes/class-string-locator.php
@@ -368,7 +368,7 @@ class String_Locator {
 		}
 
 		$table = sprintf(
-			'<table class="%s" id="string-locator-search-results-table"><thead>%s</thead><tbody>%s</tbody><tfoot>%s</tfoot></table>',
+			'<table class="%s" id="string-locator-search-results-table"><thead>%s</thead><tbody id="string-locator-search-results-tbody">%s</tbody><tfoot>%s</tfoot></table>',
 			implode( ' ', $table_class ),
 			$table_columns,
 			implode( "\n", $table_rows ),

--- a/src/javascript/string-locator-search.js
+++ b/src/javascript/string-locator-search.js
@@ -15,7 +15,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		searchRegex = document.getElementById( 'string-locator-regex' ),
 		tableContainerWrapper = document.getElementById( 'string-locator-search-results-table-wrapper' ),
 		tableWrapper = document.getElementById( 'string-locator-search-results-table' ),
-		tableBody = document.getElementsByTagName( 'tbody' )[ 0 ];
+		tableBody = document.getElementById( 'string-locator-search-results-tbody' );
 
 	function addNotice( title, message, format ) {
 		noticeWrapper.innerHTML += '<div class="notice notice-' + format + ' is-dismissible"><p><strong>' + title + '</strong><br />' + message + '</p></div>';


### PR DESCRIPTION
When rendering the search results, String Locator attempts to create all the table rows in the very first `tbody` tag detected in the document. If there are _any_ other `tbody` tags being rendered on the page, the results get added to the wrong element (which in my case was hidden behind the Autoptimize dropdown in the admin bar). This PR simply gives the correct `tbody` tag an `id` attribute and updates the render code to use that unambiguous `id`.

Screenshot of display error:
![string-locator-tbody-error](https://user-images.githubusercontent.com/6260923/185691708-0c22b813-bdf8-4567-8164-6c649dd071a6.png)
